### PR TITLE
Updated 20220911

### DIFF
--- a/ClientSideServiceDiscovery/api/v1/error.go
+++ b/ClientSideServiceDiscovery/api/v1/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -13,7 +14,7 @@ type ErrOffsetOutOfRange struct {
 
 func (e ErrOffsetOutOfRange) GRPCStatus() *status.Status {
 	st := status.New(
-		404,
+		codes.OutOfRange,
 		fmt.Sprintf("offset out of range: %d", e.Offset),
 	)
 	msg := fmt.Sprintf(

--- a/ClientSideServiceDiscovery/internal/log/index.go
+++ b/ClientSideServiceDiscovery/internal/log/index.go
@@ -47,6 +47,9 @@ func (i *index) Close() error {
 	if err := i.mmap.Sync(gommap.MS_SYNC); err != nil {
 		return err
 	}
+	if err := i.mmap.UnsafeUnmap(); err != nil {
+		return err
+	}
 	if err := i.file.Sync(); err != nil {
 		return err
 	}

--- a/ClientSideServiceDiscovery/internal/log/log.go
+++ b/ClientSideServiceDiscovery/internal/log/log.go
@@ -106,11 +106,11 @@ func (l *Log) Read(off uint64) (*api.Record, error) {
 			break
 		}
 	}
-	// START: before
-	if s == nil || s.nextOffset <= off {
+
+	if s == nil {
 		return nil, api.ErrOffsetOutOfRange{Offset: off}
 	}
-	// END: before
+
 	return s.Read(off)
 }
 

--- a/ClientSideServiceDiscovery/internal/log/segment_test.go
+++ b/ClientSideServiceDiscovery/internal/log/segment_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSegment(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "segment-test")
+	dir, err := os.MkdirTemp("", "segment-test")
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	want := &api.Record{Value: []byte("hello world")}

--- a/CoordinateWithConsensus/api/v1/error.go
+++ b/CoordinateWithConsensus/api/v1/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -13,7 +14,7 @@ type ErrOffsetOutOfRange struct {
 
 func (e ErrOffsetOutOfRange) GRPCStatus() *status.Status {
 	st := status.New(
-		404,
+		codes.OutOfRange,
 		fmt.Sprintf("offset out of range: %d", e.Offset),
 	)
 	msg := fmt.Sprintf(

--- a/CoordinateWithConsensus/internal/log/index.go
+++ b/CoordinateWithConsensus/internal/log/index.go
@@ -47,6 +47,9 @@ func (i *index) Close() error {
 	if err := i.mmap.Sync(gommap.MS_SYNC); err != nil {
 		return err
 	}
+	if err := i.mmap.UnsafeUnmap(); err != nil {
+		return err
+	}
 	if err := i.file.Sync(); err != nil {
 		return err
 	}

--- a/CoordinateWithConsensus/internal/log/log.go
+++ b/CoordinateWithConsensus/internal/log/log.go
@@ -106,11 +106,11 @@ func (l *Log) Read(off uint64) (*api.Record, error) {
 			break
 		}
 	}
-	// START: before
-	if s == nil || s.nextOffset <= off {
+
+	if s == nil {
 		return nil, api.ErrOffsetOutOfRange{Offset: off}
 	}
-	// END: before
+
 	return s.Read(off)
 }
 

--- a/CoordinateWithConsensus/internal/log/segment_test.go
+++ b/CoordinateWithConsensus/internal/log/segment_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSegment(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "segment-test")
+	dir, err := os.MkdirTemp("", "segment-test")
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	want := &api.Record{Value: []byte("hello world")}

--- a/DeployLocally/api/v1/error.go
+++ b/DeployLocally/api/v1/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -13,7 +14,7 @@ type ErrOffsetOutOfRange struct {
 
 func (e ErrOffsetOutOfRange) GRPCStatus() *status.Status {
 	st := status.New(
-		404,
+		codes.OutOfRange,
 		fmt.Sprintf("offset out of range: %d", e.Offset),
 	)
 	msg := fmt.Sprintf(

--- a/DeployLocally/internal/log/log.go
+++ b/DeployLocally/internal/log/log.go
@@ -106,11 +106,11 @@ func (l *Log) Read(off uint64) (*api.Record, error) {
 			break
 		}
 	}
-	// START: before
-	if s == nil || s.nextOffset <= off {
+
+	if s == nil {
 		return nil, api.ErrOffsetOutOfRange{Offset: off}
 	}
-	// END: before
+
 	return s.Read(off)
 }
 

--- a/DeployLocally/internal/log/segment_test.go
+++ b/DeployLocally/internal/log/segment_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSegment(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "segment-test")
+	dir, err := os.MkdirTemp("", "segment-test")
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	want := &api.Record{Value: []byte("hello world")}

--- a/DeployToCloud/api/v1/error.go
+++ b/DeployToCloud/api/v1/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -13,7 +14,7 @@ type ErrOffsetOutOfRange struct {
 
 func (e ErrOffsetOutOfRange) GRPCStatus() *status.Status {
 	st := status.New(
-		404,
+		codes.OutOfRange,
 		fmt.Sprintf("offset out of range: %d", e.Offset),
 	)
 	msg := fmt.Sprintf(

--- a/DeployToCloud/internal/log/log.go
+++ b/DeployToCloud/internal/log/log.go
@@ -106,11 +106,11 @@ func (l *Log) Read(off uint64) (*api.Record, error) {
 			break
 		}
 	}
-	// START: before
-	if s == nil || s.nextOffset <= off {
+
+	if s == nil {
 		return nil, api.ErrOffsetOutOfRange{Offset: off}
 	}
-	// END: before
+
 	return s.Read(off)
 }
 

--- a/DeployToCloud/internal/log/segment_test.go
+++ b/DeployToCloud/internal/log/segment_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSegment(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "segment-test")
+	dir, err := os.MkdirTemp("", "segment-test")
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	want := &api.Record{Value: []byte("hello world")}

--- a/ObserveYourServices/api/v1/error.go
+++ b/ObserveYourServices/api/v1/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -13,7 +14,7 @@ type ErrOffsetOutOfRange struct {
 
 func (e ErrOffsetOutOfRange) GRPCStatus() *status.Status {
 	st := status.New(
-		404,
+		codes.OutOfRange,
 		fmt.Sprintf("offset out of range: %d", e.Offset),
 	)
 	msg := fmt.Sprintf(

--- a/ObserveYourServices/internal/log/index.go
+++ b/ObserveYourServices/internal/log/index.go
@@ -47,6 +47,9 @@ func (i *index) Close() error {
 	if err := i.mmap.Sync(gommap.MS_SYNC); err != nil {
 		return err
 	}
+	if err := i.mmap.UnsafeUnmap(); err != nil {
+		return err
+	}
 	if err := i.file.Sync(); err != nil {
 		return err
 	}

--- a/ObserveYourServices/internal/log/log.go
+++ b/ObserveYourServices/internal/log/log.go
@@ -106,11 +106,11 @@ func (l *Log) Read(off uint64) (*api.Record, error) {
 			break
 		}
 	}
-	// START: before
-	if s == nil || s.nextOffset <= off {
+
+	if s == nil {
 		return nil, api.ErrOffsetOutOfRange{Offset: off}
 	}
-	// END: before
+
 	return s.Read(off)
 }
 

--- a/ObserveYourServices/internal/log/segment_test.go
+++ b/ObserveYourServices/internal/log/segment_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSegment(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "segment-test")
+	dir, err := os.MkdirTemp("", "segment-test")
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	want := &api.Record{Value: []byte("hello world")}

--- a/SecureYourServices/api/v1/error.go
+++ b/SecureYourServices/api/v1/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -13,7 +14,7 @@ type ErrOffsetOutOfRange struct {
 
 func (e ErrOffsetOutOfRange) GRPCStatus() *status.Status {
 	st := status.New(
-		404,
+		codes.OutOfRange,
 		fmt.Sprintf("offset out of range: %d", e.Offset),
 	)
 	msg := fmt.Sprintf(

--- a/SecureYourServices/internal/log/index.go
+++ b/SecureYourServices/internal/log/index.go
@@ -47,6 +47,9 @@ func (i *index) Close() error {
 	if err := i.mmap.Sync(gommap.MS_SYNC); err != nil {
 		return err
 	}
+	if err := i.mmap.UnsafeUnmap(); err != nil {
+		return err
+	}
 	if err := i.file.Sync(); err != nil {
 		return err
 	}

--- a/SecureYourServices/internal/log/log.go
+++ b/SecureYourServices/internal/log/log.go
@@ -106,11 +106,11 @@ func (l *Log) Read(off uint64) (*api.Record, error) {
 			break
 		}
 	}
-	// START: before
-	if s == nil || s.nextOffset <= off {
+
+	if s == nil {
 		return nil, api.ErrOffsetOutOfRange{Offset: off}
 	}
-	// END: before
+
 	return s.Read(off)
 }
 

--- a/SecureYourServices/internal/log/segment_test.go
+++ b/SecureYourServices/internal/log/segment_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSegment(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "segment-test")
+	dir, err := os.MkdirTemp("", "segment-test")
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	want := &api.Record{Value: []byte("hello world")}

--- a/ServeRequestsWithgRPC/api/v1/error.go
+++ b/ServeRequestsWithgRPC/api/v1/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -13,7 +14,7 @@ type ErrOffsetOutOfRange struct {
 
 func (e ErrOffsetOutOfRange) GRPCStatus() *status.Status {
 	st := status.New(
-		404,
+		codes.OutOfRange,
 		fmt.Sprintf("offset out of range: %d", e.Offset),
 	)
 	msg := fmt.Sprintf(

--- a/ServeRequestsWithgRPC/internal/log/index.go
+++ b/ServeRequestsWithgRPC/internal/log/index.go
@@ -47,6 +47,9 @@ func (i *index) Close() error {
 	if err := i.mmap.Sync(gommap.MS_SYNC); err != nil {
 		return err
 	}
+	if err := i.mmap.UnsafeUnmap(); err != nil {
+		return err
+	}
 	if err := i.file.Sync(); err != nil {
 		return err
 	}

--- a/ServeRequestsWithgRPC/internal/log/log.go
+++ b/ServeRequestsWithgRPC/internal/log/log.go
@@ -106,11 +106,11 @@ func (l *Log) Read(off uint64) (*api.Record, error) {
 			break
 		}
 	}
-	// START: before
-	if s == nil || s.nextOffset <= off {
+
+	if s == nil {
 		return nil, api.ErrOffsetOutOfRange{Offset: off}
 	}
-	// END: before
+
 	return s.Read(off)
 }
 

--- a/ServeRequestsWithgRPC/internal/log/segment_test.go
+++ b/ServeRequestsWithgRPC/internal/log/segment_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSegment(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "segment-test")
+	dir, err := os.MkdirTemp("", "segment-test")
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	want := &api.Record{Value: []byte("hello world")}

--- a/ServerSideServiceDiscovery/api/v1/error.go
+++ b/ServerSideServiceDiscovery/api/v1/error.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	codes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
@@ -13,7 +14,7 @@ type ErrOffsetOutOfRange struct {
 
 func (e ErrOffsetOutOfRange) GRPCStatus() *status.Status {
 	st := status.New(
-		404,
+		codes.OutOfRange,
 		fmt.Sprintf("offset out of range: %d", e.Offset),
 	)
 	msg := fmt.Sprintf(

--- a/ServerSideServiceDiscovery/internal/log/index.go
+++ b/ServerSideServiceDiscovery/internal/log/index.go
@@ -47,6 +47,9 @@ func (i *index) Close() error {
 	if err := i.mmap.Sync(gommap.MS_SYNC); err != nil {
 		return err
 	}
+	if err := i.mmap.UnsafeUnmap(); err != nil {
+		return err
+	}
 	if err := i.file.Sync(); err != nil {
 		return err
 	}

--- a/ServerSideServiceDiscovery/internal/log/log.go
+++ b/ServerSideServiceDiscovery/internal/log/log.go
@@ -106,11 +106,11 @@ func (l *Log) Read(off uint64) (*api.Record, error) {
 			break
 		}
 	}
-	// START: before
-	if s == nil || s.nextOffset <= off {
+
+	if s == nil {
 		return nil, api.ErrOffsetOutOfRange{Offset: off}
 	}
-	// END: before
+
 	return s.Read(off)
 }
 

--- a/ServerSideServiceDiscovery/internal/log/segment_test.go
+++ b/ServerSideServiceDiscovery/internal/log/segment_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSegment(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "segment-test")
+	dir, err := os.MkdirTemp("", "segment-test")
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	want := &api.Record{Value: []byte("hello world")}

--- a/WriteALogPackage/internal/log/index.go
+++ b/WriteALogPackage/internal/log/index.go
@@ -47,6 +47,9 @@ func (i *index) Close() error {
 	if err := i.mmap.Sync(gommap.MS_SYNC); err != nil {
 		return err
 	}
+	if err := i.mmap.UnsafeUnmap(); err != nil {
+		return err
+	}
 	if err := i.file.Sync(); err != nil {
 		return err
 	}

--- a/WriteALogPackage/internal/log/log.go
+++ b/WriteALogPackage/internal/log/log.go
@@ -106,7 +106,7 @@ func (l *Log) Read(off uint64) (*api.Record, error) {
 			break
 		}
 	}
-	if s == nil || s.nextOffset <= off {
+	if s == nil {
 		return nil, fmt.Errorf("offset out of range: %d", off)
 	}
 	return s.Read(off)

--- a/WriteALogPackage/internal/log/segment_test.go
+++ b/WriteALogPackage/internal/log/segment_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestSegment(t *testing.T) {
-	dir, _ := os.MkdirTemp("", "segment-test")
+	dir, err := os.MkdirTemp("", "segment-test")
+	require.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	want := &api.Record{Value: []byte("hello world")}


### PR DESCRIPTION
Fixed codes:

- 404 -> codes.OutOfRange
- Unmap index file
- Delete  unnecessary condition
- Handle os.MkdirTemp call consistently.